### PR TITLE
Add unit tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,14 +5,14 @@ const { setFetchFunction } = require( './lib/fetch' );
 const { fetchNotifications, getAdditionalDataFetcher } = require( './lib/fetchers' );
 
 // Used to make sure invalid api responses still have a unique ID
-let uniqueIndex = 0;
+let uniqueIndex = Date.now();
 
 function convertToGitnews( notifications ) {
 	return notifications.map( apiData => {
 		if ( ! apiData ) {
 			apiData = {};
 		}
-		uniqueIndex += 1;
+		uniqueIndex += Date.now();
 		return {
 			api: {
 				notification: apiData,

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const md5Hex = require( 'md5-hex' );
 const { setLogger } = require( './lib/logger' );
+const { setFetchFunction } = require( './lib/fetch' );
 const { fetchNotifications, getAdditionalDataFetcher } = require( './lib/fetchers' );
 
 function convertToGitnews( notifications ) {
@@ -37,5 +38,6 @@ function getNotifications( token, params = {} ) {
 
 module.exports = {
 	setLogger,
+	setFetchFunction,
 	getNotifications,
 };

--- a/index.js
+++ b/index.js
@@ -1,25 +1,29 @@
 const md5Hex = require( 'md5-hex' );
+const get = require( 'lodash.get' );
 const { setLogger } = require( './lib/logger' );
 const { setFetchFunction } = require( './lib/fetch' );
 const { fetchNotifications, getAdditionalDataFetcher } = require( './lib/fetchers' );
 
 function convertToGitnews( notifications ) {
 	return notifications.map( apiData => {
+		if ( ! apiData ) {
+			apiData = {};
+		}
 		return {
 			api: {
 				notification: apiData,
 				subject: null, // will be filled-in later
 				comment: null, // will be filled-in later
 			},
-			id: md5Hex( apiData.id + apiData.updated_at ),
+			id: md5Hex( get( apiData, 'id', 0 ) + get( apiData, 'updated_at', '1' ) ),
 			unread: apiData.unread,
-			title: apiData.subject.title,
-			type: apiData.subject.type,
+			title: get( apiData, 'subject.title' ),
+			type: get( apiData, 'subject.type' ),
 			updatedAt: apiData.updated_at,
 			'private': apiData.private,
-			repositoryName: apiData.repository.name,
-			repositoryFullName: apiData.repository.full_name,
-			repositoryOwnerAvatar: apiData.repository.owner.avatar_url,
+			repositoryName: get( apiData, 'repository.name' ),
+			repositoryFullName: get( apiData, 'repository.full_name' ),
+			repositoryOwnerAvatar: get( apiData, 'repository.owner.avatar_url' ),
 			subjectUrl: null, // will be filled-in later
 			commentUrl: null, // will be filled-in later
 			commentAvatar: null, // will be filled-in later

--- a/index.js
+++ b/index.js
@@ -4,18 +4,22 @@ const { setLogger } = require( './lib/logger' );
 const { setFetchFunction } = require( './lib/fetch' );
 const { fetchNotifications, getAdditionalDataFetcher } = require( './lib/fetchers' );
 
+// Used to make sure invalid api responses still have a unique ID
+let uniqueIndex = 0;
+
 function convertToGitnews( notifications ) {
 	return notifications.map( apiData => {
 		if ( ! apiData ) {
 			apiData = {};
 		}
+		uniqueIndex += 1;
 		return {
 			api: {
 				notification: apiData,
 				subject: null, // will be filled-in later
 				comment: null, // will be filled-in later
 			},
-			id: md5Hex( get( apiData, 'id', 0 ) + get( apiData, 'updated_at', '1' ) ),
+			id: md5Hex( get( apiData, 'id', uniqueIndex ) + get( apiData, 'updated_at', '1' ) ),
 			unread: apiData.unread,
 			title: get( apiData, 'subject.title' ),
 			type: get( apiData, 'subject.type' ),

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -1,0 +1,17 @@
+const nodeFetch = require( 'node-fetch' );
+
+let fetchFunction = nodeFetch;
+
+function fetch( url, init = null ) {
+	return fetchFunction( url, init );
+}
+
+function setFetchFunction( func ) {
+	fetchFunction = func;
+}
+
+module.exports = {
+	fetch,
+	setFetchFunction,
+};
+

--- a/lib/fetchers.js
+++ b/lib/fetchers.js
@@ -26,7 +26,8 @@ function fetchNotifications( token, params = {} ) {
 	return fetch( withQuery( 'https://api.github.com/notifications', params ), getFetchInit( token ) )
 		.then( checkForHttpErrors )
 		.then( convertToJson )
-		.then( checkForErrors );
+		.then( checkForErrors )
+		.then( checkForArray );
 }
 
 function fetchNotificationSubjectUrl( token, note ) {
@@ -64,6 +65,13 @@ function checkForHttpErrors( response ) {
 		return Promise.reject( response );
 	}
 	return Promise.resolve( response );
+}
+
+function checkForArray( result ) {
+	if ( ! result.map ) {
+		return Promise.reject( new Error( 'Notifications list is not an array.' ) );
+	}
+	return Promise.resolve( result );
 }
 
 function checkForErrors( result ) {

--- a/lib/fetchers.js
+++ b/lib/fetchers.js
@@ -77,7 +77,7 @@ function checkForArray( result ) {
 function checkForErrors( result ) {
 	return new Promise( ( resolve, reject ) => {
 		if ( result.message ) {
-			return reject( result.message );
+			return reject( new Error( result.message ) );
 		}
 		resolve( result );
 	} );

--- a/lib/fetchers.js
+++ b/lib/fetchers.js
@@ -31,7 +31,7 @@ function fetchNotifications( token, params = {} ) {
 }
 
 function fetchNotificationSubjectUrl( token, note ) {
-	const url = note.api.notification.subject.url;
+	const url = get( note, 'api.notification.subject.url', '' );
 	log( `fetching subject data for ${ url }` );
 	return fetch( url, getFetchInit( token ) )
 		.then( convertToJson )
@@ -44,7 +44,8 @@ function fetchNotificationSubjectUrl( token, note ) {
 }
 
 function fetchNotificationCommentData( token, note ) {
-	const url = note.api.notification.subject.latest_comment_url || note.api.notification.subject.url;
+	const subject = get( note, 'api.notification.subject', {} );
+	const url = subject.latest_comment_url || subject.url || '';
 	log( `fetching comment data for ${ url }` );
 	return fetch( url, getFetchInit( token ) )
 		.then( convertToJson )

--- a/lib/fetchers.js
+++ b/lib/fetchers.js
@@ -63,7 +63,7 @@ function fetchNotificationCommentData( token, note ) {
 
 function checkForHttpErrors( response ) {
 	if ( ! response.ok ) {
-		throw new Error( 'Network response was not ok.' );
+		return Promise.reject( response );
 	}
 	return Promise.resolve( response );
 }

--- a/lib/fetchers.js
+++ b/lib/fetchers.js
@@ -1,7 +1,7 @@
-const fetch = require( 'node-fetch' );
 const get = require( 'lodash.get' );
 const withQuery = require( 'with-query' );
 const { log } = require( './logger' );
+const { fetch } = require( './fetch' );
 
 function getFetchInit( token ) {
 	return {

--- a/lib/fetchers.js
+++ b/lib/fetchers.js
@@ -18,11 +18,9 @@ function convertToJson( result ) {
 
 function fetchNotifications( token, params = {} ) {
 	if ( ! token ) {
-		return new Promise( ( resolve, reject ) => {
-			const err = new Error( 'GitHub token is not available' );
-			err.code = 'GitHubTokenNotFound';
-			reject( err );
-		} );
+		const err = new Error( 'GitHub token is not available' );
+		err.code = 'GitHubTokenNotFound';
+		return Promise.reject( err );
 	}
 	log( 'fetching notifications...' );
 	return fetch( withQuery( 'https://api.github.com/notifications', params ), getFetchInit( token ) )

--- a/lib/fetchers.js
+++ b/lib/fetchers.js
@@ -26,6 +26,7 @@ function fetchNotifications( token, params = {} ) {
 	}
 	log( 'fetching notifications...' );
 	return fetch( withQuery( 'https://api.github.com/notifications', params ), getFetchInit( token ) )
+		.then( checkForHttpErrors )
 		.then( convertToJson )
 		.then( checkForErrors );
 }
@@ -34,6 +35,7 @@ function fetchNotificationSubjectUrl( token, note ) {
 	const url = get( note, 'api.notification.subject.url', '' );
 	log( `fetching subject data for ${ url }` );
 	return fetch( url, getFetchInit( token ) )
+		.then( checkForHttpErrors )
 		.then( convertToJson )
 		.then( checkForErrors )
 		.then( subject => {
@@ -48,6 +50,7 @@ function fetchNotificationCommentData( token, note ) {
 	const url = subject.latest_comment_url || subject.url || '';
 	log( `fetching comment data for ${ url }` );
 	return fetch( url, getFetchInit( token ) )
+		.then( checkForHttpErrors )
 		.then( convertToJson )
 		.then( checkForErrors )
 		.then( comment => {
@@ -56,6 +59,13 @@ function fetchNotificationCommentData( token, note ) {
 			note.commentAvatar = get( comment, 'user.avatar_url' );
 			return note;
 		} );
+}
+
+function checkForHttpErrors( response ) {
+	if ( ! response.ok ) {
+		throw new Error( 'Network response was not ok.' );
+	}
+	return Promise.resolve( response );
 }
 
 function checkForErrors( result ) {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,10 @@
     "node-fetch": "^1.6.3",
     "with-query": "^1.0.2"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "chai": "^4.1.0",
+    "mocha": "^3.4.2"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/sirbrillig/gitnews.git"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "chai": "^4.1.0",
+    "chai-subset": "^1.5.0",
     "mocha": "^3.4.2"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Fetch GitHub notifications",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha"
   },
   "author": "Payton Swick <payton@foolord.com>",
   "license": "MIT",

--- a/test/gitnews.js
+++ b/test/gitnews.js
@@ -142,115 +142,119 @@ describe( 'gitnews', function() {
 				} );
 		} );
 
-		it( 'resolves with an array of notifications', function() {
-			setFetchFunction( getMockFetch( [ {}, {} ] ) );
-			return getNotifications( '123abc' )
-				.then( results => {
-					expect( results ).to.have.length( 2 );
-				} );
-		} );
+		describe( 'when it resolves', function() {
+			it( 'is an array', function() {
+				setFetchFunction( getMockFetch( [ {}, {} ] ) );
+				return getNotifications( '123abc' )
+					.then( results => {
+						expect( results ).to.have.length( 2 );
+					} );
+			} );
 
-		it( 'resolves with notifications that each have a unique id with invalid data', function() {
-			setFetchFunction( getMockFetch( [ {}, {} ] ) );
-			return getNotifications( '123abc' )
-				.then( results => {
-					expect( results[ 0 ].id ).to.not.equal( results[ 1 ].id );
+			describe( 'each notification', function() {
+				it( 'has a unique id even when data is invalid', function() {
+					setFetchFunction( getMockFetch( [ {}, {} ] ) );
+					return getNotifications( '123abc' )
+						.then( results => {
+							expect( results[ 0 ].id ).to.not.equal( results[ 1 ].id );
+						} );
 				} );
-		} );
 
-		it( 'resolves with notifications that each have a unique id with valid data', function() {
-			setFetchFunction( getMockFetch( [
-				{ id: 5, updated_at: '123454' }, // eslint-disable-line camelcase
-				{ id: 6, updated_at: '123456' }, // eslint-disable-line camelcase
-			] ) );
-			return getNotifications( '123abc' )
-				.then( results => {
-					expect( results[ 0 ].id ).to.not.equal( results[ 1 ].id );
+				it( 'has a unique id when data is valid', function() {
+					setFetchFunction( getMockFetch( [
+						{ id: 5, updated_at: '123454' }, // eslint-disable-line camelcase
+						{ id: 6, updated_at: '123456' }, // eslint-disable-line camelcase
+					] ) );
+					return getNotifications( '123abc' )
+						.then( results => {
+							expect( results[ 0 ].id ).to.not.equal( results[ 1 ].id );
+						} );
 				} );
-		} );
 
-		it( 'resolves with notifications that each include raw api responses', function() {
-			setFetchFunction( getMockFetchForPatterns( {
-				notification: { json: [
-					{ id: 5, foo: 'bar', subject: { url: 'subjectUrl' } },
-					{ id: 6, subject: { url: 'subjectUrl' } },
-				] },
-				subjectUrl: { json: { html_url: 'htmlUrl' } }, // eslint-disable-line camelcase
-			} ) );
-			return getNotifications( '123abc' )
-				.then( results => {
-					expect( results[ 0 ].api.notification.foo ).to.equal( 'bar' );
-					expect( results[ 1 ].api.subject.html_url ).to.equal( 'htmlUrl' );
-					expect( results[ 1 ].api.comment.html_url ).to.equal( 'htmlUrl' );
+				it( 'includes the raw api responses', function() {
+					setFetchFunction( getMockFetchForPatterns( {
+						notification: { json: [
+							{ id: 5, foo: 'bar', subject: { url: 'subjectUrl' } },
+							{ id: 6, subject: { url: 'subjectUrl' } },
+						] },
+						subjectUrl: { json: { html_url: 'htmlUrl' } }, // eslint-disable-line camelcase
+					} ) );
+					return getNotifications( '123abc' )
+						.then( results => {
+							expect( results[ 0 ].api.notification.foo ).to.equal( 'bar' );
+							expect( results[ 1 ].api.subject.html_url ).to.equal( 'htmlUrl' );
+							expect( results[ 1 ].api.comment.html_url ).to.equal( 'htmlUrl' );
+						} );
 				} );
-		} );
 
-		it( 'resolves with notifications that each include subjectUrl', function() {
-			setFetchFunction( getMockFetchForPatterns( {
-				notification: { json: [
-					{ id: 5, subject: { url: 'subjectUrl' } },
-				] },
-				subjectUrl: { json: { html_url: 'htmlUrl' } }, // eslint-disable-line camelcase
-			} ) );
-			return getNotifications( '123abc' )
-				.then( results => {
-					expect( results[ 0 ].subjectUrl ).to.equal( 'htmlUrl' );
+				it( 'includes subjectUrl', function() {
+					setFetchFunction( getMockFetchForPatterns( {
+						notification: { json: [
+							{ id: 5, subject: { url: 'subjectUrl' } },
+						] },
+						subjectUrl: { json: { html_url: 'htmlUrl' } }, // eslint-disable-line camelcase
+					} ) );
+					return getNotifications( '123abc' )
+						.then( results => {
+							expect( results[ 0 ].subjectUrl ).to.equal( 'htmlUrl' );
+						} );
 				} );
-		} );
 
-		it( 'resolves with notifications that each include commentUrl set to subjectUrl if no commentUrl exists', function() {
-			setFetchFunction( getMockFetchForPatterns( {
-				notification: { json: [
-					{ id: 5, subject: { url: 'subjectUrl' } },
-				] },
-				subjectUrl: { json: { html_url: 'htmlUrl' } }, // eslint-disable-line camelcase
-			} ) );
-			return getNotifications( '123abc' )
-				.then( results => {
-					expect( results[ 0 ].commentUrl ).to.equal( 'htmlUrl' );
+				it( 'includes commentUrl set to subjectUrl if no comment exists', function() {
+					setFetchFunction( getMockFetchForPatterns( {
+						notification: { json: [
+							{ id: 5, subject: { url: 'subjectUrl' } },
+						] },
+						subjectUrl: { json: { html_url: 'htmlUrl' } }, // eslint-disable-line camelcase
+					} ) );
+					return getNotifications( '123abc' )
+						.then( results => {
+							expect( results[ 0 ].commentUrl ).to.equal( 'htmlUrl' );
+						} );
 				} );
-		} );
 
-		it( 'resolves with notifications that each include commentUrl set to commentUrl if commentUrl exists', function() {
-			setFetchFunction( getMockFetchForPatterns( {
-				notification: { json: [
-					{ id: 5, subject: { url: 'subjectUrl', latest_comment_url: 'commentUrl' } }, // eslint-disable-line camelcase
-				] },
-				subjectUrl: { json: { html_url: 'htmlSubjectUrl' } }, // eslint-disable-line camelcase
-				commentUrl: { json: { html_url: 'htmlCommentUrl' } }, // eslint-disable-line camelcase
-			} ) );
-			return getNotifications( '123abc' )
-				.then( results => {
-					expect( results[ 0 ].commentUrl ).to.equal( 'htmlCommentUrl' );
+				it( 'includes commentUrl set to commentUrl if a comment exists', function() {
+					setFetchFunction( getMockFetchForPatterns( {
+						notification: { json: [
+							{ id: 5, subject: { url: 'subjectUrl', latest_comment_url: 'commentUrl' } }, // eslint-disable-line camelcase
+						] },
+						subjectUrl: { json: { html_url: 'htmlSubjectUrl' } }, // eslint-disable-line camelcase
+						commentUrl: { json: { html_url: 'htmlCommentUrl' } }, // eslint-disable-line camelcase
+					} ) );
+					return getNotifications( '123abc' )
+						.then( results => {
+							expect( results[ 0 ].commentUrl ).to.equal( 'htmlCommentUrl' );
+						} );
 				} );
-		} );
 
-		it( 'resolves with notifications that each include commentAvatar set to last comment avatar_url if it exists', function() {
-			setFetchFunction( getMockFetchForPatterns( {
-				notification: { json: [
-					{ id: 5, subject: { url: 'subjectUrl', latest_comment_url: 'commentUrl' } }, // eslint-disable-line camelcase
-				] },
-				subjectUrl: { json: { html_url: 'htmlSubjectUrl' } }, // eslint-disable-line camelcase
-				commentUrl: { json: { html_url: 'htmlCommentUrl', user: { avatar_url: 'avatarUrl' } } }, // eslint-disable-line camelcase
-			} ) );
-			return getNotifications( '123abc' )
-				.then( results => {
-					expect( results[ 0 ].commentAvatar ).to.equal( 'avatarUrl' );
+				it( 'includes commentAvatar set to last comment avatar_url if a comment exists', function() {
+					setFetchFunction( getMockFetchForPatterns( {
+						notification: { json: [
+							{ id: 5, subject: { url: 'subjectUrl', latest_comment_url: 'commentUrl' } }, // eslint-disable-line camelcase
+						] },
+						subjectUrl: { json: { html_url: 'htmlSubjectUrl' } }, // eslint-disable-line camelcase
+						commentUrl: { json: { html_url: 'htmlCommentUrl', user: { avatar_url: 'avatarUrl' } } }, // eslint-disable-line camelcase
+					} ) );
+					return getNotifications( '123abc' )
+						.then( results => {
+							expect( results[ 0 ].commentAvatar ).to.equal( 'avatarUrl' );
+						} );
 				} );
-		} );
 
-		it( 'resolves with notifications that each include commentAvatar set to subject avatar_url if no comment exists', function() {
-			setFetchFunction( getMockFetchForPatterns( {
-				notification: { json: [
-					{ id: 5, subject: { url: 'subjectUrl' } }, // eslint-disable-line camelcase
-				] },
-				subjectUrl: { json: { html_url: 'htmlSubjectUrl', user: { avatar_url: 'subjectAvatarUrl' } } }, // eslint-disable-line camelcase
-				commentUrl: { json: { html_url: 'htmlCommentUrl', user: { avatar_url: 'commentAvatarUrl' } } }, // eslint-disable-line camelcase
-			} ) );
-			return getNotifications( '123abc' )
-				.then( results => {
-					expect( results[ 0 ].commentAvatar ).to.equal( 'subjectAvatarUrl' );
+				it( 'includes commentAvatar set to subject avatar_url if no comment exists', function() {
+					setFetchFunction( getMockFetchForPatterns( {
+						notification: { json: [
+							{ id: 5, subject: { url: 'subjectUrl' } }, // eslint-disable-line camelcase
+						] },
+						subjectUrl: { json: { html_url: 'htmlSubjectUrl', user: { avatar_url: 'subjectAvatarUrl' } } }, // eslint-disable-line camelcase
+						commentUrl: { json: { html_url: 'htmlCommentUrl', user: { avatar_url: 'commentAvatarUrl' } } }, // eslint-disable-line camelcase
+					} ) );
+					return getNotifications( '123abc' )
+						.then( results => {
+							expect( results[ 0 ].commentAvatar ).to.equal( 'subjectAvatarUrl' );
+						} );
 				} );
+			} );
 		} );
 	} );
 } );

--- a/test/gitnews.js
+++ b/test/gitnews.js
@@ -109,6 +109,24 @@ describe( 'gitnews', function() {
 				} );
 		} );
 
+		it( 'rejects if the notifications were fetched but fetching the comment failed', function() {
+			const mockFetch = ( url ) => {
+				if ( !! url.match( /notifications|subjectUrl/ ) ) {
+					return Promise.resolve( getResponseObject( [ { id: 1, subject: { url: 'subjectUrl', latest_comment_url: 'commentUrl' } } ] ) ); // eslint-disable-line camelcase
+				}
+				if ( !! url.match( 'commentUrl' ) ) {
+					return Promise.resolve( getResponseObject( null, { status: 418 } ) );
+				}
+				return Promise.resolve( getResponseObject( null, { status: 500 } ) );
+			};
+			setFetchFunction( mockFetch );
+			return getNotifications( '123abc' )
+				.catch( isError )
+				.then( err => {
+					expect( err.status ).to.equal( 418 );
+				} );
+		} );
+
 		it( 'resolves with an array of notifications', function() {
 			setFetchFunction( getMockFetch( [ {}, {} ] ) );
 			return getNotifications( '123abc' )

--- a/test/gitnews.js
+++ b/test/gitnews.js
@@ -197,5 +197,60 @@ describe( 'gitnews', function() {
 					expect( results[ 0 ].subjectUrl ).to.equal( 'htmlUrl' );
 				} );
 		} );
+
+		it( 'resolves with notifications that each include commentUrl set to subjectUrl if no commentUrl exists', function() {
+			setFetchFunction( getMockFetchForPatterns( {
+				notification: { json: [
+					{ id: 5, subject: { url: 'subjectUrl' } },
+				] },
+				subjectUrl: { json: { html_url: 'htmlUrl' } }, // eslint-disable-line camelcase
+			} ) );
+			return getNotifications( '123abc' )
+				.then( results => {
+					expect( results[ 0 ].commentUrl ).to.equal( 'htmlUrl' );
+				} );
+		} );
+
+		it( 'resolves with notifications that each include commentUrl set to commentUrl if commentUrl exists', function() {
+			setFetchFunction( getMockFetchForPatterns( {
+				notification: { json: [
+					{ id: 5, subject: { url: 'subjectUrl', latest_comment_url: 'commentUrl' } }, // eslint-disable-line camelcase
+				] },
+				subjectUrl: { json: { html_url: 'htmlSubjectUrl' } }, // eslint-disable-line camelcase
+				commentUrl: { json: { html_url: 'htmlCommentUrl' } }, // eslint-disable-line camelcase
+			} ) );
+			return getNotifications( '123abc' )
+				.then( results => {
+					expect( results[ 0 ].commentUrl ).to.equal( 'htmlCommentUrl' );
+				} );
+		} );
+
+		it( 'resolves with notifications that each include commentAvatar set to last comment avatar_url if it exists', function() {
+			setFetchFunction( getMockFetchForPatterns( {
+				notification: { json: [
+					{ id: 5, subject: { url: 'subjectUrl', latest_comment_url: 'commentUrl' } }, // eslint-disable-line camelcase
+				] },
+				subjectUrl: { json: { html_url: 'htmlSubjectUrl' } }, // eslint-disable-line camelcase
+				commentUrl: { json: { html_url: 'htmlCommentUrl', user: { avatar_url: 'avatarUrl' } } }, // eslint-disable-line camelcase
+			} ) );
+			return getNotifications( '123abc' )
+				.then( results => {
+					expect( results[ 0 ].commentAvatar ).to.equal( 'avatarUrl' );
+				} );
+		} );
+
+		it( 'resolves with notifications that each include commentAvatar set to subject avatar_url if no comment exists', function() {
+			setFetchFunction( getMockFetchForPatterns( {
+				notification: { json: [
+					{ id: 5, subject: { url: 'subjectUrl' } }, // eslint-disable-line camelcase
+				] },
+				subjectUrl: { json: { html_url: 'htmlSubjectUrl', user: { avatar_url: 'subjectAvatarUrl' } } }, // eslint-disable-line camelcase
+				commentUrl: { json: { html_url: 'htmlCommentUrl', user: { avatar_url: 'commentAvatarUrl' } } }, // eslint-disable-line camelcase
+			} ) );
+			return getNotifications( '123abc' )
+				.then( results => {
+					expect( results[ 0 ].commentAvatar ).to.equal( 'subjectAvatarUrl' );
+				} );
+		} );
 	} );
 } );

--- a/test/gitnews.js
+++ b/test/gitnews.js
@@ -37,12 +37,33 @@ describe( 'gitnews', function() {
 		it( 'rejects if no token was provided with code GitHubTokenNotFound', function() {
 			setFetchFunction( getMockFetch( [ {} ], { status: 200 } ) );
 			return getNotifications()
-				.then( () => {
-					return Promise.reject( 'Missing token did not reject Promise.' );
-				} )
 				.catch( isError )
 				.then( err => {
 					expect( err.code ).to.equal( 'GitHubTokenNotFound' );
+				} );
+		} );
+
+		it( 'rejects if the server returns an error message', function() {
+			setFetchFunction( getMockFetch( { message: 'something failed' } ) );
+			return getNotifications( '123abc' )
+				.then( () => {
+					return Promise.reject( 'Failure message did not reject Promise.' );
+				} )
+				.catch( isError )
+				.then( err => {
+					expect( err.message ).to.equal( 'something failed' );
+				} );
+		} );
+
+		it( 'rejects if the server returns a non-array', function() {
+			setFetchFunction( getMockFetch( { foo: 'bar' } ) );
+			return getNotifications( '123abc' )
+				.then( () => {
+					return Promise.reject( 'Non-array did not reject Promise.' );
+				} )
+				.catch( isError )
+				.then( err => {
+					expect( err.message ).to.equal( 'Notifications list is not an array.' );
 				} );
 		} );
 

--- a/test/gitnews.js
+++ b/test/gitnews.js
@@ -20,5 +20,24 @@ describe( 'gitnews', function() {
 					expect( results ).to.have.length( 2 );
 				} );
 		} );
+
+		it( 'resolves with notifications that each have a unique id with invalid data', function() {
+			setFetchFunction( getMockFetch( [ {}, {} ] ) );
+			return getNotifications( '123abc' )
+				.then( results => {
+					expect( results[ 0 ].id ).to.not.equal( results[ 1 ].id );
+				} );
+		} );
+
+		it( 'resolves with notifications that each have a unique id with valid data', function() {
+			setFetchFunction( getMockFetch( [
+				{ id: 5, updated_at: '123454' }, // eslint-disable-line camelcase
+				{ id: 6, updated_at: '123456' }, // eslint-disable-line camelcase
+			] ) );
+			return getNotifications( '123abc' )
+				.then( results => {
+					expect( results[ 0 ].id ).to.not.equal( results[ 1 ].id );
+				} );
+		} );
 	} );
 } );

--- a/test/gitnews.js
+++ b/test/gitnews.js
@@ -13,6 +13,16 @@ const { expect } = chai;
 
 describe( 'gitnews', function() {
 	describe( 'getNotifications()', function() {
+		it( 'requests the GitHub notifications API', function() {
+			return new Promise( ( resolve ) => {
+				setFetchFunction( resolve );
+				getNotifications( '123abc' );
+			} )
+				.then( ( url ) => {
+					expect( url ).to.equal( 'https://api.github.com/notifications?all=true' );
+				} );
+		} );
+
 		it( 'rejects if no token was provided', function() {
 			setFetchFunction( getMockFetch( [ {} ], { status: 200 } ) );
 			return getNotifications()

--- a/test/gitnews.js
+++ b/test/gitnews.js
@@ -22,6 +22,30 @@ function isError( e ) {
 
 describe( 'gitnews', function() {
 	describe( 'getNotifications()', function() {
+		it( 'rejects if no token was provided', function() {
+			setFetchFunction( getMockFetch( [ {} ], { status: 200 } ) );
+			return getNotifications()
+				.then( () => {
+					return Promise.reject( 'Missing token did not reject Promise.' );
+				} )
+				.catch( isError )
+				.then( err => {
+					expect( err ).to.be.ok;
+				} );
+		} );
+
+		it( 'rejects if no token was provided with code GitHubTokenNotFound', function() {
+			setFetchFunction( getMockFetch( [ {} ], { status: 200 } ) );
+			return getNotifications()
+				.then( () => {
+					return Promise.reject( 'Missing token did not reject Promise.' );
+				} )
+				.catch( isError )
+				.then( err => {
+					expect( err.code ).to.equal( 'GitHubTokenNotFound' );
+				} );
+		} );
+
 		it( 'rejects if the server returns an http error', function() {
 			setFetchFunction( getMockFetch( [ {} ], { status: 400 } ) );
 			return getNotifications( '123abc' )

--- a/test/gitnews.js
+++ b/test/gitnews.js
@@ -2,17 +2,27 @@
 const { expect } = require( 'chai' );
 const { getNotifications, setFetchFunction } = require( '../index' );
 
-function getMockFetch( responseJson ) {
-	const mockResponse = { json: () => responseJson };
-	return function mockFetch() {
-		return new Promise( ( resolve ) => {
-			resolve( mockResponse );
-		} );
+function getMockFetch( responseJson, statusData = {} ) {
+	const status = statusData.status || 200;
+	const mockResponse = {
+		ok: status > 199 && status < 300,
+		status,
+		statusText: statusData.statusText || 'OK',
+		json: () => Promise.resolve( responseJson ),
 	};
+	return () => Promise.resolve( mockResponse );
 }
 
 describe( 'gitnews', function() {
 	describe( 'getNotifications()', function() {
+		it( 'rejects if the server returns an http error', function( done ) {
+			setFetchFunction( getMockFetch( [ {} ], { status: 400 } ) );
+			getNotifications( '123abc' )
+				.catch( () => {
+					done();
+				} );
+		} );
+
 		it( 'resolves with an array of notifications', function() {
 			setFetchFunction( getMockFetch( [ {}, {} ] ) );
 			return getNotifications( '123abc' )

--- a/test/gitnews.js
+++ b/test/gitnews.js
@@ -113,16 +113,13 @@ describe( 'gitnews', function() {
 		} );
 
 		it( 'rejects if the notifications were fetched but fetching the subject failed', function() {
-			const mockFetch = ( url ) => {
-				if ( !! url.match( /notifications/ ) ) {
-					return Promise.resolve( getResponseObject( [ { id: 1, subject: { url: 'subjectUrl' } } ] ) );
-				}
-				if ( !! url.match( 'subjectUrl' ) ) {
-					return Promise.resolve( getResponseObject( null, { status: 418 } ) );
-				}
-				return Promise.resolve( getResponseObject( null, { status: 500 } ) );
-			};
-			setFetchFunction( mockFetch );
+			setFetchFunction( getMockFetchForPatterns( {
+				notifications: {
+					json: [ { id: 1, subject: { url: 'subjectUrl', latest_comment_url: 'commentUrl' } } ], // eslint-disable-line camelcase
+				},
+				subjectUrl: { status: 418 },
+				'.': { status: 500 }
+			} ) );
 			return getNotifications( '123abc' )
 				.catch( isError )
 				.then( err => {
@@ -131,16 +128,13 @@ describe( 'gitnews', function() {
 		} );
 
 		it( 'rejects if the notifications were fetched but fetching the comment failed', function() {
-			const mockFetch = ( url ) => {
-				if ( !! url.match( /notifications|subjectUrl/ ) ) {
-					return Promise.resolve( getResponseObject( [ { id: 1, subject: { url: 'subjectUrl', latest_comment_url: 'commentUrl' } } ] ) ); // eslint-disable-line camelcase
-				}
-				if ( !! url.match( 'commentUrl' ) ) {
-					return Promise.resolve( getResponseObject( null, { status: 418 } ) );
-				}
-				return Promise.resolve( getResponseObject( null, { status: 500 } ) );
-			};
-			setFetchFunction( mockFetch );
+			setFetchFunction( getMockFetchForPatterns( {
+				'notifications|subjectUrl': {
+					json: [ { id: 1, subject: { url: 'subjectUrl', latest_comment_url: 'commentUrl' } } ], // eslint-disable-line camelcase
+				},
+				commentUrl: { status: 418 },
+				'.': { status: 500 }
+			} ) );
 			return getNotifications( '123abc' )
 				.catch( isError )
 				.then( err => {

--- a/test/gitnews.js
+++ b/test/gitnews.js
@@ -153,5 +153,16 @@ describe( 'gitnews', function() {
 					expect( results[ 0 ].id ).to.not.equal( results[ 1 ].id );
 				} );
 		} );
+
+		it( 'resolves with notifications that each include raw api responses', function() {
+			setFetchFunction( getMockFetch( [
+				{ id: 5, foo: 'bar' },
+				{ id: 6 },
+			] ) );
+			return getNotifications( '123abc' )
+				.then( results => {
+					expect( results[ 0 ].api.notification.foo ).to.equal( 'bar' );
+				} );
+		} );
 	} );
 } );

--- a/test/gitnews.js
+++ b/test/gitnews.js
@@ -13,13 +13,33 @@ function getMockFetch( responseJson, statusData = {} ) {
 	return () => Promise.resolve( mockResponse );
 }
 
+function isError( e ) {
+	if ( typeof e === 'string' ) {
+		return Promise.reject( new Error( e ) );
+	}
+	return Promise.resolve( e );
+}
+
 describe( 'gitnews', function() {
 	describe( 'getNotifications()', function() {
-		it( 'rejects if the server returns an http error', function( done ) {
+		it( 'rejects if the server returns an http error', function() {
 			setFetchFunction( getMockFetch( [ {} ], { status: 400 } ) );
-			getNotifications( '123abc' )
-				.catch( () => {
-					done();
+			return getNotifications( '123abc' )
+				.then( () => {
+					return Promise.reject( 'Failed http did not reject Promise.' );
+				} )
+				.catch( isError )
+				.then( err => {
+					expect( err ).to.be.ok;
+				} );
+		} );
+
+		it( 'rejects with the status code if the server returns an http error', function() {
+			setFetchFunction( getMockFetch( [ {} ], { status: 418 } ) );
+			return getNotifications( '123abc' )
+				.catch( isError )
+				.then( err => {
+					expect( err.status ).to.equal( 418 );
 				} );
 		} );
 

--- a/test/gitnews.js
+++ b/test/gitnews.js
@@ -2,51 +2,14 @@
 const chai = require( 'chai' );
 const chaiSubset = require( 'chai-subset' );
 const { getNotifications, setFetchFunction } = require( '../index' );
+const {
+	isError,
+	getMockFetchForPatterns,
+	getMockFetch,
+} = require( './helpers.js' );
 
 chai.use( chaiSubset );
 const { expect } = chai;
-
-function getResponseObject( responseJson, statusData = {} ) {
-	const status = statusData.status || 200;
-	return {
-		ok: status > 199 && status < 300,
-		status,
-		statusText: statusData.statusText || 'OK',
-		json: () => Promise.resolve( responseJson ),
-	};
-}
-
-function getMockResponseObject( responseData ) {
-	const json = responseData.json || null;
-	const status = responseData.status || 200;
-	return {
-		ok: status > 199 && status < 300,
-		status,
-		statusText: responseData.statusText || 'OK',
-		json: () => Promise.resolve( json ),
-	};
-}
-
-function getMockFetch( responseJson, statusData = {} ) {
-	return () => Promise.resolve( getResponseObject( responseJson, statusData ) );
-}
-
-function getMockFetchForPatterns( patterns ) {
-	return ( url ) => {
-		const matchedPattern = Object.keys( patterns ).find( pattern => url.match( pattern ) );
-		if ( matchedPattern ) {
-			return Promise.resolve( getMockResponseObject( patterns[ matchedPattern ] ) );
-		}
-		return Promise.resolve( getMockResponseObject( { status: 500 } ) );
-	};
-}
-
-function isError( e ) {
-	if ( typeof e === 'string' ) {
-		return Promise.reject( new Error( e ) );
-	}
-	return Promise.resolve( e );
-}
 
 describe( 'gitnews', function() {
 	describe( 'getNotifications()', function() {

--- a/test/gitnews.js
+++ b/test/gitnews.js
@@ -1,0 +1,24 @@
+/* global describe, it */
+const { expect } = require( 'chai' );
+const { getNotifications, setFetchFunction } = require( '../index' );
+
+function getMockFetch( responseJson ) {
+	const mockResponse = { json: () => responseJson };
+	return function mockFetch() {
+		return new Promise( ( resolve ) => {
+			resolve( mockResponse );
+		} );
+	};
+}
+
+describe( 'gitnews', function() {
+	describe( 'getNotifications()', function() {
+		it( 'resolves with an array of notifications', function() {
+			setFetchFunction( getMockFetch( [ {}, {} ] ) );
+			return getNotifications( '123abc' )
+				.then( results => {
+					expect( results ).to.have.length( 2 );
+				} );
+		} );
+	} );
+} );

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,38 @@
+function getMockResponseObject( responseData ) {
+	const json = responseData.json || null;
+	const status = responseData.status || 200;
+	return {
+		ok: status > 199 && status < 300,
+		status,
+		statusText: responseData.statusText || 'OK',
+		json: () => Promise.resolve( json ),
+	};
+}
+
+function getMockFetch( responseJson, statusData = {} ) {
+	return () => Promise.resolve( getMockResponseObject( { json: responseJson, status: statusData.status, statusText: statusData.statusText } ) );
+}
+
+function getMockFetchForPatterns( patterns ) {
+	return ( url ) => {
+		const matchedPattern = Object.keys( patterns ).find( pattern => url.match( pattern ) );
+		if ( matchedPattern ) {
+			return Promise.resolve( getMockResponseObject( patterns[ matchedPattern ] ) );
+		}
+		return Promise.resolve( getMockResponseObject( { status: 500 } ) );
+	};
+}
+
+function isError( e ) {
+	if ( typeof e === 'string' ) {
+		return Promise.reject( new Error( e ) );
+	}
+	return Promise.resolve( e );
+}
+
+module.exports = {
+	isError,
+	getMockFetchForPatterns,
+	getMockFetch,
+	getMockResponseObject,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -21,6 +21,10 @@ browser-stdout@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.0.tgz#f351d32969d32fa5d7a5567154263d928ae3bd1f"
 
+chai-subset@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/chai-subset/-/chai-subset-1.5.0.tgz#d03dbcfa8c9daad848643bbde4e63376b7882427"
+
 chai@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/chai/-/chai-4.1.0.tgz#331a0391b55c3af8740ae9c3b7458bc1c3805e6d"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,23 +2,180 @@
 # yarn lockfile v1
 
 
+assertion-error@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.0.2.tgz#13ca515d86206da0bac66e834dd397d87581094c"
+
+balanced-match@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
+
+brace-expansion@^1.1.7:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.8.tgz#c07b211c7c952ec1f8efd51a77ef0d1d3990a292"
+  dependencies:
+    balanced-match "^1.0.0"
+    concat-map "0.0.1"
+
+browser-stdout@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.0.tgz#f351d32969d32fa5d7a5567154263d928ae3bd1f"
+
+chai@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-4.1.0.tgz#331a0391b55c3af8740ae9c3b7458bc1c3805e6d"
+  dependencies:
+    assertion-error "^1.0.1"
+    check-error "^1.0.1"
+    deep-eql "^2.0.1"
+    get-func-name "^2.0.0"
+    pathval "^1.0.0"
+    type-detect "^4.0.0"
+
+check-error@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
+
+commander@2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
+  dependencies:
+    graceful-readlink ">= 1.0.0"
+
+concat-map@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+
+debug@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.0.tgz#bc596bcabe7617f11d9fa15361eded5608b8499b"
+  dependencies:
+    ms "0.7.2"
+
+deep-eql@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-2.0.2.tgz#b1bac06e56f0a76777686d50c9feb75c2ed7679a"
+  dependencies:
+    type-detect "^3.0.0"
+
+diff@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
+
 encoding@^0.1.11:
   version "0.1.12"
   resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
   dependencies:
     iconv-lite "~0.4.13"
 
+escape-string-regexp@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
+
+fs.realpath@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+
+get-func-name@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
+
+glob@7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.2"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+"graceful-readlink@>= 1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
+
+growl@1.9.2:
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/growl/-/growl-1.9.2.tgz#0ea7743715db8d8de2c5ede1775e1b45ac85c02f"
+
+has-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
+
 iconv-lite@~0.4.13:
   version "0.4.17"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.17.tgz#4fdaa3b38acbc2c031b045d0edcdfe1ecab18c8d"
+
+inflight@^1.0.4:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
+  dependencies:
+    once "^1.3.0"
+    wrappy "1"
+
+inherits@2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
 is-stream@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
+json3@3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.2.tgz#3c0434743df93e2f5c42aee7b19bcb483575f4e1"
+
+lodash._baseassign@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz#8c38a099500f215ad09e59f1722fd0c52bfe0a4e"
+  dependencies:
+    lodash._basecopy "^3.0.0"
+    lodash.keys "^3.0.0"
+
+lodash._basecopy@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz#8da0e6a876cf344c0ad8a54882111dd3c5c7ca36"
+
+lodash._basecreate@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz#1bc661614daa7fc311b7d03bf16806a0213cf821"
+
+lodash._getnative@^3.0.0:
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
+
+lodash._isiterateecall@^3.0.0:
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz#5203ad7ba425fae842460e696db9cf3e6aac057c"
+
+lodash.create@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.create/-/lodash.create-3.1.1.tgz#d7f2849f0dbda7e04682bb8cd72ab022461debe7"
+  dependencies:
+    lodash._baseassign "^3.0.0"
+    lodash._basecreate "^3.0.0"
+    lodash._isiterateecall "^3.0.0"
+
 lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+
+lodash.isarguments@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
+
+lodash.isarray@^3.0.0:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
+
+lodash.keys@^3.0.0:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-3.1.2.tgz#4dbc0472b156be50a0b286855d1bd0b0c656098a"
+  dependencies:
+    lodash._getnative "^3.0.0"
+    lodash.isarguments "^3.0.0"
+    lodash.isarray "^3.0.0"
 
 md5-hex@^2.0.0:
   version "2.0.0"
@@ -29,6 +186,42 @@ md5-hex@^2.0.0:
 md5-o-matic@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/md5-o-matic/-/md5-o-matic-0.1.1.tgz#822bccd65e117c514fab176b25945d54100a03c3"
+
+minimatch@^3.0.2:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
+  dependencies:
+    brace-expansion "^1.1.7"
+
+minimist@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
+
+mkdirp@0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
+  dependencies:
+    minimist "0.0.8"
+
+mocha@^3.4.2:
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-3.4.2.tgz#d0ef4d332126dbf18d0d640c9b382dd48be97594"
+  dependencies:
+    browser-stdout "1.3.0"
+    commander "2.9.0"
+    debug "2.6.0"
+    diff "3.2.0"
+    escape-string-regexp "1.0.5"
+    glob "7.1.1"
+    growl "1.9.2"
+    json3 "3.3.2"
+    lodash.create "3.1.1"
+    mkdirp "0.5.1"
+    supports-color "3.1.2"
+
+ms@0.7.2:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
 
 node-fetch@^1.6.3:
   version "1.6.3"
@@ -41,9 +234,37 @@ object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
+once@^1.3.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
+  dependencies:
+    wrappy "1"
+
+path-is-absolute@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+
+pathval@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
+
 qs@^6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
+
+supports-color@3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
+  dependencies:
+    has-flag "^1.0.0"
+
+type-detect@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-3.0.0.tgz#46d0cc8553abb7b13a352b0d6dea2fd58f2d9b55"
+
+type-detect@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.3.tgz#0e3f2670b44099b0b46c284d136a7ef49c74c2ea"
 
 with-query@^1.0.2:
   version "1.0.2"
@@ -51,3 +272,7 @@ with-query@^1.0.2:
   dependencies:
     object-assign "^4.1.1"
     qs "^6.4.0"
+
+wrappy@1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"


### PR DESCRIPTION
This allows us to simulate and verify all kinds of responses and prevent several classes of bugs.

Hopefully fixes #1 

TODO: 
- [ ] ~add tests for 200 response but non-JSON body~ I think this is impossible since `response.json()` is async
- [x] add tests for 200 response but `message` error
- [x] add tests for successful fetch of notifications but failed subject fetch
- [x] add tests for successful fetch of notifications but failed comment fetch
- [x] add tests for all notification fields
- [x] add tests for avatar images
- [x] add tests for API urls and query params for all three fetches