### PR TITLE
Allow 404 in comment url

### DIFF
--- a/lib/fetchers.js
+++ b/lib/fetchers.js
@@ -1,4 +1,5 @@
 const get = require( 'lodash.get' );
+const { Response } = require( 'node-fetch' );
 const withQuery = require( 'with-query' );
 
 function getFetchInit( token ) {
@@ -48,6 +49,7 @@ function fetchNotificationCommentData( getter, token, note ) {
 	getter.log( `fetching comment data for ${ url }` );
 	return getter.fetch( url, getFetchInit( token ) )
 		.then( checkForHttpErrors )
+		.catch( getAllowMissingResource( getter, subject.url || '', token ) )
 		.then( convertToJson )
 		.then( checkForErrors )
 		.then( comment => {
@@ -56,6 +58,15 @@ function fetchNotificationCommentData( getter, token, note ) {
 			note.commentAvatar = get( comment, 'user.avatar_url' );
 			return note;
 		} );
+}
+
+function getAllowMissingResource( getter, replacementUrl, token ) {
+	return function allowMissingResource( response ) {
+		if ( response.status === 404 ) {
+			return getter.fetch( replacementUrl, getFetchInit( token ) );
+		}
+		return Promise.reject( response );
+	};
 }
 
 function checkForHttpErrors( response ) {

--- a/test/gitnews.js
+++ b/test/gitnews.js
@@ -240,7 +240,21 @@ describe( 'gitnews', function() {
 							{ id: 5, subject: { url: 'subjectUrl' } }, // eslint-disable-line camelcase
 						] },
 						subjectUrl: { json: { html_url: 'htmlSubjectUrl', user: { avatar_url: 'subjectAvatarUrl' } } }, // eslint-disable-line camelcase
-						commentUrl: { json: { html_url: 'htmlCommentUrl', user: { avatar_url: 'commentAvatarUrl' } } }, // eslint-disable-line camelcase
+					} );
+					const getNotifications = createNoteGetter( { fetch } );
+					return getNotifications( '123abc' )
+						.then( results => {
+							expect( results[ 0 ].commentAvatar ).to.equal( 'subjectAvatarUrl' );
+						} );
+				} );
+
+				it( 'includes commentAvatar set to subject avatar_url if comment returns a 404', function() {
+					const fetch = getMockFetchForPatterns( {
+						notification: { json: [
+							{ id: 5, subject: { url: 'subjectUrl', latest_comment_url: 'commentUrl' } }, // eslint-disable-line camelcase
+						] },
+						subjectUrl: { json: { html_url: 'htmlSubjectUrl', user: { avatar_url: 'subjectAvatarUrl' } } }, // eslint-disable-line camelcase
+						commentUrl: { status: 404 },
 					} );
 					const getNotifications = createNoteGetter( { fetch } );
 					return getNotifications( '123abc' )


### PR DESCRIPTION
Sometimes a comment may be deleted and still be reported as a URL in the notification. In that case it's better to just silently ignore the 404 from the comment URL rather than fail with an error.