### PR TITLE
Add `markNotificationRead`

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,29 @@ const { createNoteGetter } = require( 'gitnews' );
 const getNotifications = createNoteGetter( { log: message => console.log( message ) } );
 getNotifications( token );
 ```
+
+## Marking Notifications Read
+
+The main purpose of this module is to retreieve notification URLs. Once a notification URL is visited, it typically marks the notification as read. In some cases (eg: security warnings), that does not happen. In these cases, it might be useful to manually mark a notification as read. This module exports the `markNotificationRead` function which can be used to do this.
+
+The `markNotificationRead` function requires two arguments:
+
+- The token.
+- The notification object that resulted from calling getNotifications.
+
+The following example marks all notifications as read.
+
+```js
+const { getNotifications, markNotificationRead } = require( 'gitnews' );
+getNotifications( token )
+	.then( notes => notes.filter( note => note.unread ) )
+	.then( notes => notes.map( note => markNotificationRead( token, note ) ) );
+```
+
+Just like `getNotifications`, `markNotificationRead` is created by a factory function called `createNoteMarkRead`. This can be used to override the `log` and `fetch` functions.
+
+```js
+const { createNoteMarkRead } = require( 'gitnews' );
+const markNotificationRead = createNoteMarkRead( { log: message => console.log( message ) } );
+markNotificationRead( token, note );
+```

--- a/index.js
+++ b/index.js
@@ -1,5 +1,9 @@
 const nodeFetch = require( 'node-fetch' );
-const { fetchNotifications, getAdditionalDataFetcher } = require( './lib/fetchers' );
+const {
+	fetchNotifications,
+	getAdditionalDataFetcher,
+	sendMarkNotificationRead
+} = require( './lib/fetchers' );
 const { makeConverter } = require( './lib/converter' );
 
 function createNoteGetter( options = {} ) {
@@ -7,17 +11,30 @@ function createNoteGetter( options = {} ) {
 		fetch: nodeFetch,
 		log: () => {},
 	};
-	const getterOptions = Object.assign( {}, defaultOptions, options );
+	const mergedOptions = Object.assign( {}, defaultOptions, options );
 	const convertToGitnews = makeConverter();
 	return function getNotifications( token, params = {} ) {
-		const fetchAdditionalData = getAdditionalDataFetcher( getterOptions, token );
-		return fetchNotifications( getterOptions, token, Object.assign( { all: true }, params ) )
+		const fetchAdditionalData = getAdditionalDataFetcher( mergedOptions, token );
+		return fetchNotifications( mergedOptions, token, Object.assign( { all: true }, params ) )
 			.then( convertToGitnews )
 			.then( fetchAdditionalData );
 	};
 }
 
+function createNoteMarkRead( options = {} ) {
+	const defaultOptions = {
+		fetch: nodeFetch,
+		log: () => {},
+	};
+	const mergedOptions = Object.assign( {}, defaultOptions, options );
+	return function markNotificationRead( token, note, params = {} ) {
+		return sendMarkNotificationRead( mergedOptions, token, note, params );
+	};
+}
+
 module.exports = {
 	createNoteGetter,
+	createNoteMarkRead,
 	getNotifications: createNoteGetter(),
+	markNotificationRead: createNoteMarkRead(),
 };

--- a/lib/fetchers.js
+++ b/lib/fetchers.js
@@ -1,10 +1,9 @@
 const get = require( 'lodash.get' );
-const { Response } = require( 'node-fetch' );
 const withQuery = require( 'with-query' );
 
-function getFetchInit( token ) {
+function getFetchInit( token, method = 'GET' ) {
 	return {
-		method: 'GET',
+		method,
 		headers: {
 			Authorization: 'token ' + token,
 		},
@@ -103,7 +102,26 @@ function getAdditionalDataFetcher( getter, token ) {
 	};
 }
 
+function sendMarkNotificationRead( options, token, note, params ) {
+	if ( ! token ) {
+		const err = new Error( 'GitHub token is not available' );
+		err.code = 'GitHubTokenNotFound';
+		return Promise.reject( err );
+	}
+	const notificationUrl = get( note, 'api.notification.url' );
+	if ( ! notificationUrl ) {
+		const err = new Error( 'Notification has no URL' );
+		return Promise.reject( err );
+	}
+	options.log( 'marking notification read...' );
+	return options.fetch( withQuery( notificationUrl, params ), getFetchInit( token, 'PATCH' ) )
+		.then( checkForHttpErrors )
+		.then( convertToJson )
+		.then( checkForErrors );
+}
+
 module.exports = {
 	fetchNotifications,
 	getAdditionalDataFetcher,
+	sendMarkNotificationRead,
 };

--- a/lib/fetchers.js
+++ b/lib/fetchers.js
@@ -115,9 +115,7 @@ function sendMarkNotificationRead( options, token, note, params ) {
 	}
 	options.log( 'marking notification read...' );
 	return options.fetch( withQuery( notificationUrl, params ), getFetchInit( token, 'PATCH' ) )
-		.then( checkForHttpErrors )
-		.then( convertToJson )
-		.then( checkForErrors );
+		.then( checkForHttpErrors );
 }
 
 module.exports = {

--- a/test/gitnews.js
+++ b/test/gitnews.js
@@ -1,7 +1,7 @@
 /* global describe, it */
 const chai = require( 'chai' );
 const chaiSubset = require( 'chai-subset' );
-const { createNoteGetter } = require( '../index' );
+const { createNoteGetter, createNoteMarkRead } = require( '../index' );
 const {
 	isError,
 	getMockFetchForPatterns,
@@ -294,6 +294,47 @@ describe( 'gitnews', function() {
 						} );
 				} );
 			} );
+		} );
+	} );
+
+	describe( 'markNotificationRead()', function() {
+		it( 'rejects if no notification is provided', function() {
+			const fetch = getMockFetch( [ {} ], { status: 200 } );
+			const markNotificationRead = createNoteMarkRead( { fetch } );
+			markNotificationRead( '123abc' )
+				.then( () => {
+					return Promise.reject( 'Failure message did not reject Promise.' );
+				} )
+				.catch( isError )
+				.then( err => {
+					expect( err.message ).to.equal( 'Notification has no URL' );
+				} );
+		} );
+
+		it( 'marks a notification as read', function() {
+			const fetch = getMockFetchForPatterns( {
+				notification: { json: [
+					{
+						id: 5,
+						url: 'noteUrl',
+						subject: { url: 'subjectUrl', latest_comment_url: 'commentUrl', title: 'myTitle', type: 'myType' }, // eslint-disable-line camelcase
+						unread: true,
+						updated_at: '123456', // eslint-disable-line camelcase
+						'private': true,
+						repository: { name: 'myRepo', full_name: 'myFullRepo', owner: { avatar_url: 'ownerAvatarUrl' } }, // eslint-disable-line camelcase
+					},
+				] },
+				noteUrl: { method: 'PATCH', json: { ok: 'cool' } },
+				subjectUrl: { json: { html_url: 'htmlSubjectUrl' } }, // eslint-disable-line camelcase
+				commentUrl: { json: { html_url: 'htmlCommentUrl' } }, // eslint-disable-line camelcase
+			} );
+			const getNotifications = createNoteGetter( { fetch } );
+			const markNotificationRead = createNoteMarkRead( { fetch } );
+			return getNotifications( '123abc' )
+				.then( results => markNotificationRead( '123abc', results[ 0 ] ) )
+				.then( result => {
+					expect( result.ok ).to.equal( 'cool' );
+				} );
 		} );
 	} );
 } );

--- a/test/gitnews.js
+++ b/test/gitnews.js
@@ -333,7 +333,7 @@ describe( 'gitnews', function() {
 			return getNotifications( '123abc' )
 				.then( results => markNotificationRead( '123abc', results[ 0 ] ) )
 				.then( result => {
-					expect( result.ok ).to.equal( 'cool' );
+					expect( result.ok ).to.be.ok;
 				} );
 		} );
 	} );

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -14,12 +14,16 @@ function getMockFetch( responseJson, statusData = {} ) {
 }
 
 function getMockFetchForPatterns( patterns ) {
-	return ( url ) => {
-		const matchedPattern = Object.keys( patterns ).find( pattern => url.match( pattern ) );
-		if ( matchedPattern ) {
-			return Promise.resolve( getMockResponseObject( patterns[ matchedPattern ] ) );
+	return ( url, params ) => {
+		const matchedPatternKey = Object.keys( patterns ).find( pattern => url.match( pattern ) );
+		if ( ! matchedPatternKey ) {
+			return Promise.resolve( getMockResponseObject( { status: 500 } ) );
 		}
-		return Promise.resolve( getMockResponseObject( { status: 500 } ) );
+		const matchedPattern = patterns[ matchedPatternKey ];
+		if ( params.method && matchedPattern.method && matchedPattern.method !== params.method ) {
+			return Promise.resolve( getMockResponseObject( { status: 500 } ) );
+		}
+		return Promise.resolve( getMockResponseObject( matchedPattern ) );
 	};
 }
 


### PR DESCRIPTION
The main purpose of this module is to retreieve notification URLs. Once a notification URL is visited, it typically marks the notification as read. In some cases (eg: security warnings), that does not happen. In these cases, it might be useful to manually mark a notification as read. This module exports the `markNotificationRead` function which can be used to do this.

The `markNotificationRead` function requires two arguments:

- The token.
- The notification object that resulted from calling getNotifications.

The following example marks all notifications as read.

```js
const { getNotifications, markNotificationRead } = require( 'gitnews' );
getNotifications( token )
	.then( notes => notes.filter( note => note.unread ) )
	.then( notes => notes.map( note => markNotificationRead( token, note ) ) );
```

Just like `getNotifications`, `markNotificationRead` is created by a factory function called `createNoteMarkRead`. This can be used to override the `log` and `fetch` functions.

```js
const { createNoteMarkRead } = require( 'gitnews' );
const markNotificationRead = createNoteMarkRead( { log: message => console.log( message ) } );
markNotificationRead( token, note );
```
