### PR TITLE
Add guards for invalid notes

### DIFF
--- a/lib/converter.js
+++ b/lib/converter.js
@@ -19,13 +19,13 @@ function makeConverter() {
 				},
 				id: md5Hex( get( apiData, 'id', uniqueIndex ) + get( apiData, 'updated_at', '1' ) ),
 				unread: apiData.unread,
-				title: get( apiData, 'subject.title' ),
-				type: get( apiData, 'subject.type' ),
+				title: get( apiData, 'subject.title', '' ),
+				type: get( apiData, 'subject.type', '' ),
 				updatedAt: apiData.updated_at,
 				'private': apiData.private,
-				repositoryName: get( apiData, 'repository.name' ),
-				repositoryFullName: get( apiData, 'repository.full_name' ),
-				repositoryOwnerAvatar: get( apiData, 'repository.owner.avatar_url' ),
+				repositoryName: get( apiData, 'repository.name', '' ),
+				repositoryFullName: get( apiData, 'repository.full_name', '' ),
+				repositoryOwnerAvatar: get( apiData, 'repository.owner.avatar_url', '' ),
 				subjectUrl: null, // will be filled-in later
 				commentUrl: null, // will be filled-in later
 				commentAvatar: null, // will be filled-in later

--- a/lib/fetchers.js
+++ b/lib/fetchers.js
@@ -32,6 +32,10 @@ function fetchNotifications( getter, token, params = {} ) {
 function fetchNotificationSubjectUrl( getter, token, note ) {
 	const url = get( note, 'api.notification.subject.url', '' );
 	getter.log( `fetching subject data for ${ url }` );
+	if (! url)  {
+		getter.log('No url found for subject data for note: ' + JSON.stringify(note));
+		return Promise.resolve('');
+	}
 	return getter.fetch( url, getFetchInit( token ) )
 		.then( checkForHttpErrors )
 		.then( convertToJson )
@@ -47,6 +51,10 @@ function fetchNotificationCommentData( getter, token, note ) {
 	const subject = get( note, 'api.notification.subject', {} );
 	const url = subject.latest_comment_url || subject.url || '';
 	getter.log( `fetching comment data for ${ url }` );
+	if (! url)  {
+		getter.log('No url found for comment data for note: ' + JSON.stringify(note));
+		return Promise.resolve({});
+	}
 	return getter.fetch( url, getFetchInit( token ) )
 		.then( checkForHttpErrors )
 		.catch( getAllowMissingResource( getter, subject.url || '', token ) )

--- a/lib/fetchers.js
+++ b/lib/fetchers.js
@@ -34,7 +34,7 @@ function fetchNotificationSubjectUrl( getter, token, note ) {
 	getter.log( `fetching subject data for ${ url }` );
 	if (! url)  {
 		getter.log('No url found for subject data for note: ' + JSON.stringify(note));
-		return Promise.resolve('');
+		return Promise.resolve(note);
 	}
 	return getter.fetch( url, getFetchInit( token ) )
 		.then( checkForHttpErrors )
@@ -53,7 +53,7 @@ function fetchNotificationCommentData( getter, token, note ) {
 	getter.log( `fetching comment data for ${ url }` );
 	if (! url)  {
 		getter.log('No url found for comment data for note: ' + JSON.stringify(note));
-		return Promise.resolve({});
+		return Promise.resolve(note);
 	}
 	return getter.fetch( url, getFetchInit( token ) )
 		.then( checkForHttpErrors )

--- a/lib/fetchers.js
+++ b/lib/fetchers.js
@@ -5,7 +5,8 @@ function getFetchInit( token, method = 'GET' ) {
 	return {
 		method,
 		headers: {
-			Authorization: 'token ' + token,
+			Authorization: `Bearer ${token}`,
+			Accept: "application/vnd.github+json",
 		},
 	};
 }


### PR DESCRIPTION
For some reason, some notes have `null` subject URLs. This is concerning, but for now this diff adds guards to prevent fatal errors when fetching those notes.